### PR TITLE
Less classes and configurable wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Proudify takes a `hash` of options as described below:
 
 * username - your *GitHub* or *Coderwall* username (**required**)
 * service - *'github'* or *'coderwall'* (default: **github**)
+* wrap - wrap the projects/badges lists with a `div` element (default: **true**)
 * pushed_at - number of days after a repository is considered to be **ON HOLD** (default: **120 ~ 4 months**) 
 * num - limit the number of shown repositories (default: **0 - show all**)
 * forks - include forks beside your own *original* repositories (default: **false**)

--- a/jquery-proudify.js
+++ b/jquery-proudify.js
@@ -26,12 +26,20 @@
 		loading : false,
 		init : function()
 		{
-			this.wrapper = $('<div>').
-							addClass('proudify github').
-							appendTo(this.element);
-
-			this.list = $('<ul>').
-							appendTo(this.wrapper);
+			if (this.settings.wrap)
+			{
+				this.wrapper = $('<div>').
+								addClass('proudify github').
+								appendTo(this.element);
+				this.list = $('<ul>').
+								appendTo(this.wrapper);
+			}
+			else
+			{
+				this.list = $('<ul>').
+								addClass('proudify github').
+								appendTo(this.element);
+			}
 
 			this.loading = $('<li>').
 							addClass('item loading').
@@ -119,7 +127,7 @@
 		this.settings = settings;
 		this.init();
 	};
-	CoderWall.prototype = 
+	CoderWall.prototype =
 	{
 		element : false,
 		settings : {},
@@ -129,12 +137,20 @@
 		loading : false,
 		init : function()
 		{
-			this.wrapper = $('<div>').
-							addClass('proudify coderwall').
-							appendTo(this.element);
-
-			this.list = $('<ul>').
-							appendTo(this.wrapper);
+			if (this.settings.wrap)
+			{
+				this.wrapper = $('<div>').
+								addClass('proudify coderwall').
+								appendTo(this.element);
+				this.list = $('<ul>').
+								appendTo(this.wrapper);
+			}
+			else
+			{
+				this.list = $('<ul>').
+								addClass('proudify coderwall').
+								appendTo(this.element);
+			}
 
 			this.loading = $('<li>').
 							addClass('loading').
@@ -178,31 +194,32 @@
 			$('<div>').css('clear','both').appendTo(this.list);
 		}
 	};
-	
-	$.fn.proudify = function(options) 
+
+	$.fn.proudify = function(options)
 	{
-		var services = 
+		var services =
 		{
 			github : GitHub,
 			coderwall : CoderWall
 		};
-		
-		var settings = $.extend({}, 
-        						{ 
-        							username: false, 
-        							service: 'github',
-        							pushed_at: 120,
-									num: 0,
-        							forks: false,
-        							devel: false
-        						},
-       							options || {});
 
-      	if(settings.username && (settings.service in services))
-      	{
+		var settings = $.extend({},
+								{
+									username: false, 
+									service: 'github',
+									pushed_at: 120,
+									num: 0,
+									forks: false,
+									wrap: true,
+									devel: false
+								},
+								options || {});
+
+		if(settings.username && (settings.service in services))
+		{
 			new services[settings.service](this, settings);
 		}
-      	      	
+
 		return this;
 	};
 })(jQuery);

--- a/jquery-proudify.js
+++ b/jquery-proudify.js
@@ -42,7 +42,7 @@
 			}
 
 			this.loading = $('<li>').
-							addClass('item loading').
+							addClass('loading').
 							html('<span class="desc">Loading ...</span>').
 							appendTo(this.list);
 	

--- a/jquery-proudify.js
+++ b/jquery-proudify.js
@@ -31,7 +31,6 @@
 							appendTo(this.element);
 
 			this.list = $('<ul>').
-							addClass('list').
 							appendTo(this.wrapper);
 
 			this.loading = $('<li>').
@@ -135,11 +134,10 @@
 							appendTo(this.element);
 
 			this.list = $('<ul>').
-							addClass('list').
 							appendTo(this.wrapper);
 
 			this.loading = $('<li>').
-							addClass('item loading').
+							addClass('loading').
 							html('<span class="desc">Loading ...</span>').
 							appendTo(this.list);
 	
@@ -164,7 +162,7 @@
 
 			$.each(this.badges,function(i, item) 
 			{
-				var li = $('<li>').addClass('item').appendTo(self.list);
+				var li = $('<li>').appendTo(self.list);
 				var link = $('<a>').
 				attr('href', 'http://coderwall.com/' + self.settings.username).
 				attr('target', '_blank').
@@ -208,3 +206,4 @@
 		return this;
 	};
 })(jQuery);
+

--- a/jquery-proudify.js
+++ b/jquery-proudify.js
@@ -99,7 +99,7 @@
 					return false;
 				}
 				
-				var li = $('<li>').addClass('item').appendTo(self.list);
+				var li = $('<li>').appendTo(self.list);
 				
 				$('<a>').
 				attr('href', item.html_url).

--- a/proudify.css
+++ b/proudify.css
@@ -1,20 +1,20 @@
-.proudify a, 
-.proudify a:active, 
+.proudify a,
+.proudify a:active,
 .proudify a:visited
 {
 	color: white;
 	text-decoration: none;
 }
-.proudify a:hover 
-{ 
-	text-decoration: underline; 
+.proudify a:hover
+{
+	text-decoration: underline;
 }
-.proudify ul.list
+.proudify ul
 {
 	list-style-type: none;
 	padding: 0;
 }
-.proudify .loading 
+.proudify .loading
 {
 	text-align: center;
 }
@@ -22,13 +22,13 @@
 {
 	float: right;
 }
-.proudify .red 
-{ 
-	color: red; 
+.proudify .red
+{
+	color: red;
 }
-.proudify .green 
-{ 
-	color: #87EA23; 
+.proudify .green
+{
+	color: #87EA23;
 }
 .proudify .desc
 {
@@ -52,11 +52,11 @@
 	border-bottom: 1px solid #333436;
 	border-right: 1px solid #333436;
 }
-.proudify.github ul.list
+.proudify.github ul
 {
 	margin: 5px;
 }
-.proudify.github li.item
+.proudify.github li
 {
 	box-shadow: black 0px 3px 5px inset;
 	-moz-box-shadow: black 0px 3px 5px inset;
@@ -72,24 +72,25 @@
 /****** GitHub - end ******/
 
 /****** Coderwall - begin ******/
-.proudify.coderwall li.item
+.proudify.coderwall li
 {
 	float: left;
 	margin: 5px;
 }
-.proudify.coderwall li.item a img
+.proudify.coderwall li a img
 {
 	width: 90px;
 	height: 90px;
 	border: 0;
 }
-.proudify.coderwall li.item a img
+.proudify.coderwall li a img
 {
 	opacity: 1.0;
 }
-.proudify.coderwall li.item a:hover img
+.proudify.coderwall li a:hover img
 {
 	opacity: 0.6;
 }
 /****** Coderwall - end ******/
+
 


### PR DESCRIPTION
First and foremost, the requested changes are rather opinionated. So please feel free to choose not to merge any or some ;)

The first commit removes the `list` and `item` classes from the `ul` and `li` elements respectively. Having these classes is kind of redundant IMHO. Styling should not be an issue, these elements can still be styled by either using a [descendant combinator](http://www.w3.org/TR/css3-selectors/#descendant-combinators) or a [child combinators](http://www.w3.org/TR/css3-selectors/#child-combinators).

The second commit adds a configuration option to disable wrapping the `ul` element with a `div` and if set to false and adds the `proudify` and the `github`/`coderwall`classes to it instead. To me, a div inside the content area is not exactly semantically accurate unless it's completely necessary.

The minified files were intentionally left untouched.
